### PR TITLE
Fix tests failing when function keys already exists in blob storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,5 +181,7 @@ public async Task CreateOrder_Sends_Confirmation()
 | `DataDirectory`          | `AFTU_DATA_DIRECTORY`           | Directory to store Azurite data in. Defaults to TestResults directory for the given test  |
 | `UseAzuriteStorage`      | `AFTU_USE_AZURITE_STORAGE`      | Use azurite storage emulator. This should be true if using any storage related attributes |
 | `RunAzurite`             | `AFTU_RUN_AZURITE`              | Start Azurite alongside function app host                                                 |
+| `RunAzuriteSilent`       | `AFTU_AZURITE_SILENT`           | Run Azurite in silen mode                                                                 |
 | `PersistAzureContainers` | `AFTU_PERSIST_AZURE_CONTAINERS` | Decides if containers created by the function app should be persisted after test run.     |
 | `ClearStorageAfterRun`   | `AFTU_CLEAR_STORAGE_AFTER_RUN`  | Clears Azurite after each test run and provides a clean container for new runs            |
+| `WriteLog`               | `AFTU_WRITE_LOG`                | Write log to file system for Azurite and Function host. Written to `/tmp/aftu`            |

--- a/release-notes/v0.1.0-preview.md
+++ b/release-notes/v0.1.0-preview.md
@@ -7,7 +7,7 @@ Version bump release to proper version
 - Update package meta tags
 - Update README with missing env variables
 
-- [#XX](https://github.com/joachimdalen/azure-functions-test-utils/pull/XX) Setup sometimes fails because key file already exists in blob storage [#9](https://github.com/joachimdalen/azure-functions-test-utils/issues/9)
+- [#10](https://github.com/joachimdalen/azure-functions-test-utils/pull/10) Setup sometimes fails because key file already exists in blob storage [#9](https://github.com/joachimdalen/azure-functions-test-utils/issues/9)
 
 ## Maintenance
 

--- a/release-notes/v0.1.0-preview.md
+++ b/release-notes/v0.1.0-preview.md
@@ -5,6 +5,9 @@ Version bump release to proper version
 ## Changes & Fixes
 
 - Update package meta tags
+- Update README with missing env variables
+
+- [#XX](https://github.com/joachimdalen/azure-functions-test-utils/pull/XX) Setup sometimes fails because key file already exists in blob storage [#9](https://github.com/joachimdalen/azure-functions-test-utils/issues/9)
 
 ## Maintenance
 

--- a/src/JoachimDalen.AzureFunctions.TestUtils/Handlers/AzuriteHandler.cs
+++ b/src/JoachimDalen.AzureFunctions.TestUtils/Handlers/AzuriteHandler.cs
@@ -109,7 +109,7 @@ namespace JoachimDalen.AzureFunctions.TestUtils.Handlers
             if (containerNames == null || !containerNames.Any()) return;
             foreach (var container in containerNames)
             {
-                _blobServiceClient.CreateBlobContainer(container);
+                _blobServiceClient.GetBlobContainerClient(container).CreateIfNotExists();
             }
         }
 
@@ -152,7 +152,7 @@ namespace JoachimDalen.AzureFunctions.TestUtils.Handlers
 
             foreach (var queueName in queueNames)
             {
-                _queueServiceClient.CreateQueue(queueName);
+                _queueServiceClient.GetQueueClient(queueName).CreateIfNotExists();
             }
         }
 

--- a/src/JoachimDalen.AzureFunctions.TestUtils/Handlers/FunctionKeyHandler.cs
+++ b/src/JoachimDalen.AzureFunctions.TestUtils/Handlers/FunctionKeyHandler.cs
@@ -88,6 +88,9 @@ namespace JoachimDalen.AzureFunctions.TestUtils.Handlers
             };
 
             var jsonContent = JsonConvert.SerializeObject(model, Formatting.Indented);
+
+            _blobContainerClient.DeleteBlobIfExists(path);
+
             using var ms = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
             _blobContainerClient.UploadBlob(path, ms);
         }
@@ -139,6 +142,8 @@ namespace JoachimDalen.AzureFunctions.TestUtils.Handlers
                     }).ToArray(),
                 };
             }
+
+            _blobContainerClient.DeleteBlobIfExists(path);
 
             var jsonContent = JsonConvert.SerializeObject(root, Formatting.Indented);
             using var ms = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));

--- a/src/JoachimDalen.AzureFunctions.TestUtils/Handlers/FunctionKeyHandler.cs
+++ b/src/JoachimDalen.AzureFunctions.TestUtils/Handlers/FunctionKeyHandler.cs
@@ -88,9 +88,6 @@ namespace JoachimDalen.AzureFunctions.TestUtils.Handlers
             };
 
             var jsonContent = JsonConvert.SerializeObject(model, Formatting.Indented);
-
-            _blobContainerClient.DeleteBlobIfExists(path);
-
             using var ms = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
             _blobContainerClient.UploadBlob(path, ms);
         }
@@ -114,40 +111,29 @@ namespace JoachimDalen.AzureFunctions.TestUtils.Handlers
             var systemKeys = hostKeys.Where(x => x.Scope == FunctionAuthLevel.System);
             var path = Path.Join(GetFunctionHostId(), "host.json");
             var client = _blobContainerClient.GetBlobClient(path);
-            FunctionSecretRoot root;
-            if (client.Exists())
+            client.DeleteIfExists();
+            var root = new FunctionSecretRoot
             {
-                var blob = client.DownloadContent();
-                var text = Encoding.UTF8.GetString(blob.Value.Content);
-                root = JsonConvert.DeserializeObject<FunctionSecretRoot>(text);
-            }
-            else
-            {
-                root = new FunctionSecretRoot
+                MasterKey = new FunctionSecret
                 {
-                    MasterKey = new FunctionSecret
-                    {
-                        Name = "_master",
-                        Value = masterKey?.Value ?? GenerateSecret()
-                    },
-                    FunctionKeys = functionKeys.Select(x => new FunctionSecret
-                    {
-                        Name = x.Name,
-                        Value = x.Value ?? GenerateSecret()
-                    }).ToArray(),
-                    SystemKeys = systemKeys.Select(x => new FunctionSecret
-                    {
-                        Name = x.Name,
-                        Value = x.Value ?? GenerateSecret()
-                    }).ToArray(),
-                };
-            }
-
-            _blobContainerClient.DeleteBlobIfExists(path);
-
+                    Name = "_master",
+                    Value = masterKey?.Value ?? GenerateSecret()
+                },
+                FunctionKeys = functionKeys.Select(x => new FunctionSecret
+                {
+                    Name = x.Name,
+                    Value = x.Value ?? GenerateSecret()
+                }).ToArray(),
+                SystemKeys = systemKeys.Select(x => new FunctionSecret
+                {
+                    Name = x.Name,
+                    Value = x.Value ?? GenerateSecret()
+                }).ToArray(),
+            };
+            
             var jsonContent = JsonConvert.SerializeObject(root, Formatting.Indented);
             using var ms = new MemoryStream(Encoding.UTF8.GetBytes(jsonContent));
-            _blobContainerClient.UploadBlob(path, ms);
+            client.Upload(ms);
         }
     }
 }


### PR DESCRIPTION
- Fix tests failing when function keys already exists in blob storage
- Check if blob containers and queues exists before trying to create them
- Add missing environment variables to README